### PR TITLE
Update to include missing #define _BH

### DIFF
--- a/DS3231_Simple.h
+++ b/DS3231_Simple.h
@@ -36,6 +36,7 @@
 #define DS3231Easy_h
 #include <Wire.h>
 
+#define _BV(place) (1 << place)
 
 class DS3231_Simple
 {


### PR DESCRIPTION
Master doesn't include the _BH define. Adding it to the header file so examples compile.