### PR TITLE
"read only" mode for checkAlarms

### DIFF
--- a/DS3231_Simple.cpp
+++ b/DS3231_Simple.cpp
@@ -526,7 +526,7 @@ uint8_t DS3231_Simple::setAlarm(uint8_t AlarmMode)
   return setAlarm(read(), AlarmMode);
 }
 
-uint8_t DS3231_Simple::checkAlarms(uint8_t PauseClock)
+uint8_t DS3231_Simple::checkAlarms(uint8_t PauseClock, uint8_t ClearAlarms)
 {
   uint8_t StatusByte = 0;
   
@@ -540,10 +540,13 @@ uint8_t DS3231_Simple::checkAlarms(uint8_t PauseClock)
   
   rtc_i2c_read_byte(0xF,StatusByte);
 
+  if(ClearAlarms)
+  {
   if(StatusByte & 0x3)
   {
     // Clear the alarm
     rtc_i2c_write_byte(0xF,StatusByte & ~0x3);    
+  }
   }
 
   if(PauseClock)

--- a/DS3231_Simple.h
+++ b/DS3231_Simple.h
@@ -216,11 +216,14 @@ class DS3231_Simple
      *  If you pause the clock, then this won't happen, but your time keeping
      *  will not be so accurate because every time you check the alarm you will 
      *  "get behind" a small amount.
+     * 
+     *  Can be "read only" by disabling the clearing of the alarms. By default
+     *  will clear alarms.
      *  
      *  @return 0 For no alarm, 1 for Alarm 1, 2 for Alarm 2, and 3 for Both Alarms     
      */
      
-    uint8_t  checkAlarms(uint8_t PauseClock = false);
+    uint8_t  checkAlarms(uint8_t PauseClock = false, uint8_t ClearAlarms = true);
 
     /** Get the temperature accurate to within 1 degree (C)
      *  


### PR DESCRIPTION
Hello!

Your library is awesome because it provides a lot of functionality with interacting with the alarms of the DS3231, many libraries don't offer as much control.

In my use case I have the SQW pin controlling a power subsystem which is what provides power to the Arduino, and I need to check if the Arduino was turned on via an alarm or manually by calling `checkAlarms`. However, doing this also clears the alarms immediately after meaning the SQW pin floats, power to the arduino is cut and everything fails.

The `checkAlarms` function should have a "read only" mode where it doesn't change anything on the clock, just as the name implies "check" on the alarms. This means any fired alarms would stay on until you set a new alarm time and call `checkAlarms()` again but this time letting it write to the chip and letting the alarms re-prime properly.

It's a fairly simple and intuitive change that can accomplish this